### PR TITLE
chore: update test matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [18.x, 20.x, 21.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
BREAKING CHANGE: drop support for Node.js older than 18.x